### PR TITLE
Сompatibility with MultipleObjectMixin 

### DIFF
--- a/pure_pagination/paginator.py
+++ b/pure_pagination/paginator.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.core.paginator import InvalidPage
 
 from math import ceil
 import functools
@@ -9,9 +10,6 @@ PAGINATION_SETTINGS = getattr(settings, "PAGINATION_SETTINGS", {})
 
 PAGE_RANGE_DISPLAYED = PAGINATION_SETTINGS.get("PAGE_RANGE_DISPLAYED", 10)
 MARGIN_PAGES_DISPLAYED = PAGINATION_SETTINGS.get("MARGIN_PAGES_DISPLAYED", 2)
-
-class InvalidPage(Exception):
-    pass
 
 class PageNotAnInteger(InvalidPage):
     pass


### PR DESCRIPTION
I replace pure_pagination.paginator.InvalidPage to django.core.paginator.InvalidPage because django.views.generic.MultipleObjectMixin needs django.core.paginator.InvalidPage exception for render 404 page, when user use invalid page number.
