### PR TITLE
Custom Exceptions break Class Based Views

### DIFF
--- a/example_project/core/views.py
+++ b/example_project/core/views.py
@@ -3,8 +3,10 @@ from random import randint
 
 from django.http import Http404
 from django.shortcuts import render_to_response
+from django.views.generic import ListView
 
 from pure_pagination.paginator import Paginator
+from pure_pagination.mixins import PaginationMixin
 
 from core.names import names
 
@@ -31,4 +33,10 @@ def index(request):
         'page': page,
     })
 
-    
+
+class List(PaginationMixin, ListView):
+    template_name = 'list.html'
+    paginate_by = 10
+
+    def get_queryset(self):
+        return names

--- a/example_project/core/views.py
+++ b/example_project/core/views.py
@@ -37,6 +37,4 @@ def index(request):
 class List(PaginationMixin, ListView):
     template_name = 'list.html'
     paginate_by = 10
-
-    def get_queryset(self):
-        return names
+    queryset = names

--- a/example_project/urls.py
+++ b/example_project/urls.py
@@ -1,5 +1,5 @@
 from django.conf.urls.defaults import patterns, include, url
-
+from core.views import List
 # Uncomment the next two lines to enable the admin:
 # from django.contrib import admin
 # admin.autodiscover()
@@ -16,4 +16,5 @@ urlpatterns = patterns('',
     # url(r'^admin/', include(admin.site.urls)),
 
     url(r'^$', 'core.views.index', name="index"),
+    url(r'^list/$', List.as_view(), name="list"),
 )

--- a/pure_pagination/paginator.py
+++ b/pure_pagination/paginator.py
@@ -4,20 +4,12 @@ from math import ceil
 import functools
 
 from django.template.loader import render_to_string
+from django.core.paginator import InvalidPage, PageNotAnInteger, EmptyPage
 
 PAGINATION_SETTINGS = getattr(settings, "PAGINATION_SETTINGS", {})
 
 PAGE_RANGE_DISPLAYED = PAGINATION_SETTINGS.get("PAGE_RANGE_DISPLAYED", 10)
 MARGIN_PAGES_DISPLAYED = PAGINATION_SETTINGS.get("MARGIN_PAGES_DISPLAYED", 2)
-
-class InvalidPage(Exception):
-    pass
-
-class PageNotAnInteger(InvalidPage):
-    pass
-
-class EmptyPage(InvalidPage):
-    pass
 
 class Paginator(object):
     def __init__(self, object_list, per_page, orphans=0, allow_empty_first_page=True, request=None):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 from setuptools import setup, find_packages
 
 setup(name='django-pure-pagination',
-      version='0.2.1',
+      version='0.2.2',
       author='James Pacileo',
       long_description = open('README.rst').read(),
       license='BSD',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 from setuptools import setup, find_packages
 
 setup(name='django-pure-pagination',
-      version='0.2',
+      version='0.2.1',
       author='James Pacileo',
       long_description = open('README.rst').read(),
       license='BSD',


### PR DESCRIPTION
Copying the Django exceptions verbatim has the side effect of breaking the 404 handling in class based views.  

I've included a test case which shows this.

Although it seems a little counter intuitive, it seems to me that using the django pagination exceptions makes this library more compatible as a drop-in replacement.
