### PR TITLE
404 instead of 500 error for no existing page on mixin

### DIFF
--- a/pure_pagination/mixins.py
+++ b/pure_pagination/mixins.py
@@ -1,4 +1,5 @@
-from pure_pagination.paginator import Paginator
+from pure_pagination.paginator import Paginator, EmptyPage
+from django.http import Http404
 
 class PaginationMixin(object):
     """


### PR DESCRIPTION
To have a clean view from the final user, I added this to have a 404 error page if the page number does not exist instead of a 500 for the paginator mixin class
