### PR TITLE
xrange compatibility for Python 3.x

### DIFF
--- a/pure_pagination/paginator.py
+++ b/pure_pagination/paginator.py
@@ -10,6 +10,12 @@ PAGINATION_SETTINGS = getattr(settings, "PAGINATION_SETTINGS", {})
 PAGE_RANGE_DISPLAYED = PAGINATION_SETTINGS.get("PAGE_RANGE_DISPLAYED", 10)
 MARGIN_PAGES_DISPLAYED = PAGINATION_SETTINGS.get("MARGIN_PAGES_DISPLAYED", 2)
 
+# range in Python 3.x is xrange from Python 2.x
+try:
+    xrange
+except NameError:
+    xrange = range
+
 class InvalidPage(Exception):
     pass
 


### PR DESCRIPTION
`xrange` exists as `range` in python 3.x. This fixes this error when running on 3.x.