### PR TITLE
Fix querystring encoding error

### DIFF
--- a/pure_pagination/paginator.py
+++ b/pure_pagination/paginator.py
@@ -202,7 +202,7 @@ class Page(object):
         GET parameters present.
         """
         if self.paginator.request:
-            self.base_queryset['page'] = page_number
+            self.base_queryset['page'] = str(page_number)
             return self.base_queryset.urlencode()
 
         # raise Warning("You must supply Paginator() with the request object for a proper querystring.")


### PR DESCRIPTION
This fixes the querystring encoding error `AttributeError: 'int' object has no attribute 'encode'`, by converting the page number to string before applying the encoding function.