### PR TITLE
Fix for new setuptools version

### DIFF
--- a/pure_pagination/paginator.py
+++ b/pure_pagination/paginator.py
@@ -1,4 +1,4 @@
-import collections
+from collections.abs import Iterable
 
 from django.core.paginator import InvalidPage, EmptyPage, PageNotAnInteger
 from django.conf import settings
@@ -102,7 +102,7 @@ def add_page_querystring(func):
         if isinstance(result, int):
             querystring = self._other_page_querystring(result)
             return PageRepresentation(result, querystring)
-        elif isinstance(result, collections.Iterable):
+        elif isinstance(result, Iterable):
             new_result = []
             for number in result:
                 if isinstance(number, int):

--- a/pure_pagination/paginator.py
+++ b/pure_pagination/paginator.py
@@ -1,4 +1,4 @@
-from collections.abs import Iterable
+from collections.abc import Iterable
 
 from django.core.paginator import InvalidPage, EmptyPage, PageNotAnInteger
 from django.conf import settings

--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,10 @@ setup(
     url='https://github.com/jamespacileo/django-pure-pagination/',
     author='James Pacileo',
     author_email='jamespacileo@gmail.com',
-    description='''django-pure-pagination provides advanced pagination features
-                   and is fully compatible with existing code based on Django's
-                   core 
-                   pagination module. (aka no need to rewrite code!)''',
+    description=('django-pure-pagination provides advanced pagination features'
+                 ' and is fully compatible with existing code based on Django\'s'
+                 ' core'
+                 ' pagination module. (aka no need to rewrite code!)'),
     long_description=README,
     license='BSD',
     packages=find_packages(),


### PR DESCRIPTION
Setuptools no longer allows newlines in setup descriptions, which this package has. This PR removes the newlines from the description.